### PR TITLE
响应式布局：修复移动端的按钮显示被番茄钟遮挡问题

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -391,4 +391,23 @@ onUnmounted(() => {
   background: #333;
   color: white;
 }
+
+/* 窄屏适配 */
+@media (max-width: 490px) {
+  .fullscreen-btn {
+    top: auto;
+    bottom: 73px;
+    left: 20px;
+    right: auto;
+    z-index: 4;    /* 防止盖住APlayer */
+  }
+
+  .switch-video-btn {
+    top: auto;
+    bottom: 116px;
+    left: 20px;
+    right: auto;
+    z-index: 4;
+  }
+}
 </style>


### PR DESCRIPTION
### Issue

当在手机等屏幕宽度狭窄的设备上打开，番茄钟组件将会遮挡屏幕左右侧的“切换”和“全屏”按钮

### Solution

在屏幕较窄时进行响应，将两个按钮组件调整到左下角，APlayer的上方

### 效果

<img width="594" height="849" alt="image" src="https://github.com/user-attachments/assets/407e355b-6bd9-4fa4-ab25-3ef965f8e1a5" />
