### PR TITLE
修复移动端 全屏/切换按钮 的错误定位

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -395,6 +395,7 @@ onUnmounted(() => {
 /* 窄屏适配 */
 @media (max-width: 490px) {
   .fullscreen-btn {
+    position: fixed;
     top: auto;
     bottom: 73px;
     left: 20px;
@@ -403,6 +404,7 @@ onUnmounted(() => {
   }
 
   .switch-video-btn {
+    position: fixed;
     top: auto;
     bottom: 116px;
     left: 20px;


### PR DESCRIPTION
### Issue

按钮错位(位于播放器后面).

<img width="108" height="237.6" alt="image" src="https://github.com/user-attachments/assets/3e04ad22-1434-4656-9d1e-61fbbf0e8195" />

### Solution

添加 `position: fixed` 定位.
<img width="108" height="237.6" alt="image" src="https://github.com/user-attachments/assets/f7c74d14-a2a1-4a0f-b120-d37931878c23" />
